### PR TITLE
Allow swift sdk to delete a wildcard

### DIFF
--- a/CSyncSDK/Operation.swift
+++ b/CSyncSDK/Operation.swift
@@ -197,7 +197,7 @@ class PubOperation : Operation
 		}
 
 		guard !key.isKeyPattern || delete == true else {
-			error = err(CSError.invalidKey, msg:"Only delete pubs may contain a wildcard")
+			error = err(CSError.invalidKey, msg:"Key for write may not contain wildcard characters")
 			return nil
 		}
 

--- a/CSyncSDK/Operation.swift
+++ b/CSyncSDK/Operation.swift
@@ -196,8 +196,8 @@ class PubOperation : Operation
 			return nil
 		}
 
-		guard !key.isKeyPattern else {
-			error = err(CSError.invalidKey, msg:"Key may not contain wildcard characters")
+		guard !key.isKeyPattern || delete == true else {
+			error = err(CSError.invalidKey, msg:"Only delete pubs may contain a wildcard")
 			return nil
 		}
 

--- a/CSyncSDKTests/ListenTests.swift
+++ b/CSyncSDKTests/ListenTests.swift
@@ -156,7 +156,6 @@ class ListenTests: XCTestCase {
 
 		waitForExpectations(timeout: 10.0, handler:nil)
 	}
-
 /*
 	func testListenNullData() {
 		let expectation = expectationWithDescription("\(#function)")

--- a/CSyncSDKTests/ListenTests.swift
+++ b/CSyncSDKTests/ListenTests.swift
@@ -156,6 +156,54 @@ class ListenTests: XCTestCase {
 
 		waitForExpectations(timeout: 10.0, handler:nil)
 	}
+
+	func testDeleteWildcard(){
+		let expectation = self.expectation(description: "\(#function)")
+		let config = getConfig()
+		let uuid = UUID().uuidString
+		let app = App(host: config.host, port: config.port, options: config.options)
+		app.authenticate(config.authenticationProvider, token: config.token) { authData, error in
+			//Check to be sure the right 3 keys are deleted
+			var keyOne = false, keyTwo = false, keyThree = false
+			let listenKey = app.key("tests.DeleteWildcard." + uuid + "a.*")
+			let writeKey = app.key("tests.DeleteWildcard." + uuid + "a.b")
+			writeKey.write("b")
+			let writeKey2 = app.key("tests.DeleteWildcard." + uuid + "a.c")
+			writeKey2.write("c")
+			let writeKey3 = app.key("tests.DeleteWildcard." + uuid + "a.d")
+			writeKey3.write("d")
+			let writeKey4 = app.key("tests.DeleteWildcard." + uuid + "b.e")
+			writeKey4.write("be")
+			let writeKey5 = app.key("tests.DeleteWildcard." + uuid + "a.e.f")
+			writeKey5.write("aef")
+			let writeKey6 = app.key("tests.DeleteWildcard." + uuid + "b.a.g")
+			writeKey6.write("bag")
+			listenKey.listen { (value, error) -> () in
+				if let key = value?.key {
+					if key == "tests.DeleteWildcard." + uuid + "a.b" && (value?.exists)! == false {
+						keyOne = true
+					} else if key == "tests.DeleteWildcard." + uuid + "a.c" && value?.exists == false {
+						keyTwo = true
+					} else if key == "tests.DeleteWildcard." + uuid + "a.d" && value?.exists == false {
+						keyThree = true
+					} else if key == "tests.DeleteWildcard." + uuid + "b.e" && value?.exists == false {
+						XCTFail("a.* delete should not delete b.e")
+					} else if key == "tests.DeleteWildcard." + uuid + "a.e.f" && value?.exists == false {
+						XCTFail("a.* delete should not delete a.e.f")
+					} else if key == "tests.DeleteWildcard." + uuid + "b.a.g" && value?.exists == false {
+						XCTFail("a.* delete should not delete b.a.g")
+					}
+					//If all three keys that we expected to get deleted were deleted, pass
+					if keyOne && keyTwo && keyThree {
+						expectation.fulfill()
+					}
+				}
+			}
+			let writeKey7 = app.key("tests.DeleteWildcard." + uuid + "a.*")
+			writeKey7.delete()
+		}
+		waitForExpectations(timeout: 20.0, handler:nil)
+	}
 /*
 	func testListenNullData() {
 		let expectation = expectationWithDescription("\(#function)")

--- a/CSyncSDKTests/ListenTests.swift
+++ b/CSyncSDKTests/ListenTests.swift
@@ -157,53 +157,6 @@ class ListenTests: XCTestCase {
 		waitForExpectations(timeout: 10.0, handler:nil)
 	}
 
-	func testDeleteWildcard(){
-		let expectation = self.expectation(description: "\(#function)")
-		let config = getConfig()
-		let uuid = UUID().uuidString
-		let app = App(host: config.host, port: config.port, options: config.options)
-		app.authenticate(config.authenticationProvider, token: config.token) { authData, error in
-			//Check to be sure the right 3 keys are deleted
-			var keyOne = false, keyTwo = false, keyThree = false
-			let listenKey = app.key("tests.DeleteWildcard." + uuid + "a.*")
-			let writeKey = app.key("tests.DeleteWildcard." + uuid + "a.b")
-			writeKey.write("b")
-			let writeKey2 = app.key("tests.DeleteWildcard." + uuid + "a.c")
-			writeKey2.write("c")
-			let writeKey3 = app.key("tests.DeleteWildcard." + uuid + "a.d")
-			writeKey3.write("d")
-			let writeKey4 = app.key("tests.DeleteWildcard." + uuid + "b.e")
-			writeKey4.write("be")
-			let writeKey5 = app.key("tests.DeleteWildcard." + uuid + "a.e.f")
-			writeKey5.write("aef")
-			let writeKey6 = app.key("tests.DeleteWildcard." + uuid + "b.a.g")
-			writeKey6.write("bag")
-			listenKey.listen { (value, error) -> () in
-				if let key = value?.key {
-					if key == "tests.DeleteWildcard." + uuid + "a.b" && (value?.exists)! == false {
-						keyOne = true
-					} else if key == "tests.DeleteWildcard." + uuid + "a.c" && value?.exists == false {
-						keyTwo = true
-					} else if key == "tests.DeleteWildcard." + uuid + "a.d" && value?.exists == false {
-						keyThree = true
-					} else if key == "tests.DeleteWildcard." + uuid + "b.e" && value?.exists == false {
-						XCTFail("a.* delete should not delete b.e")
-					} else if key == "tests.DeleteWildcard." + uuid + "a.e.f" && value?.exists == false {
-						XCTFail("a.* delete should not delete a.e.f")
-					} else if key == "tests.DeleteWildcard." + uuid + "b.a.g" && value?.exists == false {
-						XCTFail("a.* delete should not delete b.a.g")
-					}
-					//If all three keys that we expected to get deleted were deleted, pass
-					if keyOne && keyTwo && keyThree {
-						expectation.fulfill()
-					}
-				}
-			}
-			let writeKey7 = app.key("tests.DeleteWildcard." + uuid + "a.*")
-			writeKey7.delete()
-		}
-		waitForExpectations(timeout: 20.0, handler:nil)
-	}
 /*
 	func testListenNullData() {
 		let expectation = expectationWithDescription("\(#function)")

--- a/CSyncSDKTests/WriteTests.swift
+++ b/CSyncSDKTests/WriteTests.swift
@@ -215,4 +215,40 @@ class WriteTests: XCTestCase {
 		waitForExpectations(timeout: 10.0, handler:nil)
 	}
 
+	func testDeleteWildcardThatDoesNotExist() {
+		let expectation = self.expectation(description: "\(#function)")
+
+		// Connect to the CSync store
+		let config = getConfig()
+		let app = App(host: config.host, port: config.port, options: config.options)
+		app.authenticate(config.authenticationProvider, token: config.token) { authData, error in
+		}
+
+		let testKey = app.key(testKeyString("\(#function)")+".*")
+		testKey.delete() {key, error in
+			// Wildcard deletes should always return success, even if nothing was deleted
+			assert(error == nil)
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 10.0, handler:nil)
+	}
+
+	func testDeleteThatDoesNotExist() {
+		let expectation = self.expectation(description: "\(#function)")
+
+		// Connect to the CSync store
+		let config = getConfig()
+		let app = App(host: config.host, port: config.port, options: config.options)
+		app.authenticate(config.authenticationProvider, token: config.token) { authData, error in
+		}
+
+		let testKey = app.key(testKeyString("\(#function)"))
+		testKey.delete() {key, error in
+			// Single Key deletes will return an error if you delete something that doesn't exist.
+			assert(error?.code == CSError.requestError.rawValue)
+			expectation.fulfill()
+		}
+		waitForExpectations(timeout: 10.0, handler:nil)
+	}
+
 }

--- a/CSyncSDKTests/WriteTests.swift
+++ b/CSyncSDKTests/WriteTests.swift
@@ -251,4 +251,52 @@ class WriteTests: XCTestCase {
 		waitForExpectations(timeout: 10.0, handler:nil)
 	}
 
+	func testDeleteWildcard(){
+		let expectation = self.expectation(description: "\(#function)")
+		let config = getConfig()
+		let uuid = UUID().uuidString
+		let app = App(host: config.host, port: config.port, options: config.options)
+		app.authenticate(config.authenticationProvider, token: config.token) { authData, error in
+			//Check to be sure the right 3 keys are deleted
+			var keyOne = false, keyTwo = false, keyThree = false
+			let listenKey = app.key("tests.DeleteWildcard." + uuid + "a.*")
+			let writeKey = app.key("tests.DeleteWildcard." + uuid + "a.b")
+			writeKey.write("b")
+			let writeKey2 = app.key("tests.DeleteWildcard." + uuid + "a.c")
+			writeKey2.write("c")
+			let writeKey3 = app.key("tests.DeleteWildcard." + uuid + "a.d")
+			writeKey3.write("d")
+			let writeKey4 = app.key("tests.DeleteWildcard." + uuid + "b.e")
+			writeKey4.write("be")
+			let writeKey5 = app.key("tests.DeleteWildcard." + uuid + "a.e.f")
+			writeKey5.write("aef")
+			let writeKey6 = app.key("tests.DeleteWildcard." + uuid + "b.a.g")
+			writeKey6.write("bag")
+			listenKey.listen { (value, error) -> () in
+				if let key = value?.key {
+					if key == "tests.DeleteWildcard." + uuid + "a.b" && (value?.exists)! == false {
+						keyOne = true
+					} else if key == "tests.DeleteWildcard." + uuid + "a.c" && value?.exists == false {
+						keyTwo = true
+					} else if key == "tests.DeleteWildcard." + uuid + "a.d" && value?.exists == false {
+						keyThree = true
+					} else if key == "tests.DeleteWildcard." + uuid + "b.e" && value?.exists == false {
+						XCTFail("a.* delete should not delete b.e")
+					} else if key == "tests.DeleteWildcard." + uuid + "a.e.f" && value?.exists == false {
+						XCTFail("a.* delete should not delete a.e.f")
+					} else if key == "tests.DeleteWildcard." + uuid + "b.a.g" && value?.exists == false {
+						XCTFail("a.* delete should not delete b.a.g")
+					}
+					//If all three keys that we expected to get deleted were deleted, pass
+					if keyOne && keyTwo && keyThree {
+						expectation.fulfill()
+					}
+				}
+			}
+			let writeKey7 = app.key("tests.DeleteWildcard." + uuid + "a.*")
+			writeKey7.delete()
+		}
+		waitForExpectations(timeout: 20.0, handler:nil)
+	}
+
 }

--- a/CSyncSDKTests/WriteTests.swift
+++ b/CSyncSDKTests/WriteTests.swift
@@ -351,7 +351,6 @@ class WriteTests: XCTestCase {
 		//Deleting something that does not exist should return a success
 		let expectation = self.expectation(description: "\(#function)")
 		let config = getConfig()
-		let uuid = UUID().uuidString
 		let app = App(host: config.host, port: config.port, options: config.options)
 		app.authenticate(config.authenticationProvider, token: config.token) { authData, error in
 			let writeKey7 = app.key("tests.DeleteNonexistantWildcard.*")


### PR DESCRIPTION
Resolves #19 
Proposed Changes:
*  Allow user to delete on wildcards
DCO1.1 Signed-off-by: Thomas Boop <tgboop@us.ibm.com>