### PR TITLE
Tgb/deliver existing values

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,7 @@ disabled_rules: # rule identifiers to exclude from running
   - todo
   - function_body_length
   - valid_docs
+  - identifier_name
 excluded: # paths to ignore during linting.
   - Carthage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ before_script:
 script: 
   - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-iOS -destination platform='iOS Simulator',name='iPhone 6',OS='10.3' clean test
   - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-iOS -destination platform='iOS Simulator',name='iPhone 6',OS='9.3' clean test
-  - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-tvOS -destination platform='tvOS Simulator',name='Apple TV 1080p',OS='10.2' clean test
-  - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-OSX -destination platform='macOS' clean test
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: objective-c
 xcode_project: CSyncSDK.xcodeproj # path to your xcodeproj folder
 xcode_scheme: CSyncSDK-iOS
-osx_image: xcode8.2
+osx_image: xcode8.3
 before_script: 
   - carthage update
   - /usr/libexec/PlistBuddy -c "Set CSYNC_HOST $CSYNC_HOST" CSyncSDKTests/Config.plist

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,10 @@ before_script:
   - /usr/libexec/PlistBuddy -c "Set CSYNC_DEMO_PROVIDER $CSYNC_DEMO_PROVIDER" CSyncSDKTests/Config.plist
   - /usr/libexec/PlistBuddy -c "Set CSYNC_DEMO_TOKEN $CSYNC_DEMO_TOKEN" CSyncSDKTests/Config.plist
 script: 
-  - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-iOS -destination platform='iOS Simulator',name='iPhone 6',OS='10.1' clean test
+  - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-iOS -destination platform='iOS Simulator',name='iPhone 6',OS='10.3' clean test
+  - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-iOS -destination platform='iOS Simulator',name='iPhone 6',OS='9.3' clean test
+  - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-tvOS -destination platform='tvOS Simulator',name='Apple TV 1080p',OS='10.2' clean test
+  - xcodebuild -project CSyncSDK.xcodeproj -scheme CSyncSDK-OSX -destination platform='macOS' clean test
 branches:
   only:
   - master

--- a/CSyncSDK/App.swift
+++ b/CSyncSDK/App.swift
@@ -409,8 +409,11 @@ public class App : NSObject
 	{
 		do {
 			let dbValues = try Latest.values(in: database, for:key)
+			//Only deliver keys that still exist at this moment.
 			for value in dbValues {
-				key.deliver(value)
+				if value.exists == true {
+					key.deliver(value)
+				}
 			}
 		} catch let err as Any {
 			logger.error("deliverFromDB failed: \(err)")

--- a/CSyncSDKTests/AppTests.swift
+++ b/CSyncSDKTests/AppTests.swift
@@ -75,7 +75,7 @@ class AppTests: XCTestCase {
 		// Connect to the CSync store
 		let config = getConfig()
 		let app = App(host: config.host, port: config.port, options: config.options)
-		app.authenticate("facebook", token: "fbtoken") { authData, error in
+		app.authenticate("Iamnotarealprovider", token: "fbtoken") { authData, error in
 			XCTAssertNotNil(error)
 			expectation.fulfill()
 		}

--- a/CSyncSDKTests/ListenTests.swift
+++ b/CSyncSDKTests/ListenTests.swift
@@ -157,6 +157,8 @@ class ListenTests: XCTestCase {
 		waitForExpectations(timeout: 10.0, handler:nil)
 	}
 
+	//Only run these tests if we support the new apis
+	#if swift(>=3.1)
 	func testNotRecieveLastValueIfDelete(){
 
 		//listens to a key, writes to it, then deletes it.
@@ -223,6 +225,8 @@ class ListenTests: XCTestCase {
 		wait(for: [expectationTwo], timeout: 10)
 		
 	}
+
+	#endif
 /*
 	func testListenNullData() {
 		let expectation = expectationWithDescription("\(#function)")


### PR DESCRIPTION
Proposed change by @dfirsht 
Proposed Changes:
*  When you listen on a key stored locally, we should only send you the local value stored if the key is not deleted
*  Updated the invalid provider test to specify a provider we do not support
*  Added unit tests for the functionality change above
*  Added testing for previous versions of iOS and updated that OSX base image to the newest
DCO1.1 Signed-off-by: Thomas Boop <tgboop@us.ibm.com>